### PR TITLE
Replace weight constant symbol in a complementary filter description

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -446,7 +446,7 @@ complementing the [=gyroscope=] values with the [=accelerometer=] values:
 With α being the weight constant, a the acceleration from [=accelerometer=], ω the angular
 velocity from [=gyroscope=] and ∂t being the time between measurements.
 
-A common value for 𝛼 is 0.98, which means that 98% of the weight lays on the [=gyroscope=]
+A common value for α is 0.98, which means that 98% of the weight lays on the [=gyroscope=]
 measurements.
 
 <div class="example">

--- a/index.html
+++ b/index.html
@@ -1792,7 +1792,7 @@ complementing the <a data-link-type="dfn" href="#gyroscope" id="ref-for-gyroscop
    <p>θ<sub>n</sub> = α × (θ<sub>n-1</sub> + ω × ∂t) + (1.0 - α) × a</p>
    <p>With α being the weight constant, a the acceleration from <a data-link-type="dfn" href="#accelerometer" id="ref-for-accelerometer-15">accelerometer</a>, ω the angular
 velocity from <a data-link-type="dfn" href="#gyroscope" id="ref-for-gyroscope-12">gyroscope</a> and ∂t being the time between measurements.</p>
-   <p>A common value for 𝛼 is 0.98, which means that 98% of the weight lays on the <a data-link-type="dfn" href="#gyroscope" id="ref-for-gyroscope-13">gyroscope</a> measurements.</p>
+   <p>A common value for α is 0.98, which means that 98% of the weight lays on the <a data-link-type="dfn" href="#gyroscope" id="ref-for-gyroscope-13">gyroscope</a> measurements.</p>
    <div class="example" id="example-7af818b7">
     <a class="self-link" href="#example-7af818b7"></a> Manually calculate the relative orientation in Euler angles (radian) using a <a data-link-type="dfn" href="#complementary-filter" id="ref-for-complementary-filter-3">complementary filter</a>. 
     <p>The <a data-link-type="dfn" href="#gyroscope" id="ref-for-gyroscope-14">gyroscope</a> measures <i><a data-link-type="dfn" href="https://w3c.github.io/gyroscope#angular-velocity">angular velocity</a></i>, so by multiplying with the time difference,


### PR DESCRIPTION
Fix #7


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/alexshalamov/motion-sensors/gh-pages.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/motion-sensors/080de69...alexshalamov:dd7f50a.html)