### PR TITLE
Editorial pass

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9,7 +9,7 @@ Editor: Kenneth Rohde Christiansen 57705, Intel Corporation, https://intel.com/
 Group: dap
 Abstract:
   This explainer is an introduction to low-level and high-level motion sensors,
-  their relation, inner workings and common use-cases. Common cases of event
+  their relationship, inner workings and common use-cases. Common cases of event
   filtering and sensor fusion are introduced with examples, showing how to apply
   that on sensors following the Generic Sensor API specification.
 Version History:
@@ -83,7 +83,7 @@ There are a handful of different motion sensors available in modern hardware suc
 as phones.
 
 The motion sensors extends the Generic Sensor API [[GENERIC-SENSOR]] to expose
-a class of low-level and fusion sensors. This document explains the relation
+a class of low-level and fusion sensors. This document explains the relationship
 between these sensors.
 
 The low-level sensors include:
@@ -107,7 +107,7 @@ Low-level Sensors {#low-level-sensors}
 ## Accelerometer ## {#accelerometer-sensor}
 
 A raw <dfn>accelerometer</dfn> sensor measures changes in acceleration in 3 different
-directions, but is affected by <i>gravity</i>. The <a>accelerometer interface</a> is defined in
+directions, but is affected by <i>gravity</i>. The <a>Accelerometer interface</a> is defined in
 [[ACCELEROMETER]] specification.
 
 The [=Accelerometer=] sensor is an <dfn>inertial-frame sensor</dfn>, this means that when the device
@@ -128,7 +128,7 @@ kinds of sensor fusion like creating a magnetic compass.
 For acceleration, you usually care about the big changes and want to avoid noise, like the
 gravity, thus a [=high-pass filter=] can help isolate the <a>linear acceleration</a> and a [=low-pass
 filter=] can help isolate the gravity. A [=low-pass filter=] can thus be useful for measuring a
-tilt. Unfortunately any high or [=low-pass filter=] introduced a delay, which may or may not be
+tilt. Unfortunately, any [=high-pass filter=] or [=low-pass filter=] introduces a delay, which may or may not be
 acceptable.
 
 Notice, as accelerometers report <i>acceleration</i>, you need to integrate to get <i>velocity</i>:
@@ -148,11 +148,11 @@ So position from an accelerometer is very imprecise and not very useful.
 
 ## Gyroscope ## {#gyroscope-sensor}
 
-A <dfn>gyroscope</dfn> senses <i><a>angular velocity</a></i>, relative to itself, thus they measure their own rotation,
-using something called the Coriolis effect. Gyroscopes oscillate at relative high frequency in
+A <dfn>gyroscope</dfn> senses <i><a>angular velocity</a></i>, relative to itself, thus it measures its own rotation,
+using an inertial force called the Coriolis effect. Gyroscopes oscillate at relative high frequency in
 order to measure this and are thus one of the most power hungry motion sensors. This also means
-that they can easily be effected by other vibrations, like a vibration (rumble) motor or speaker
-on the same device. The <a>gyroscope interface</a> is defined in
+that they can easily be affected by other vibrations, like a vibration (rumble) motor or speaker
+on the same device. The <a>Gyroscope interface</a> is defined in
 [[GYROSCOPE]] specification.
 
 In order to get rotation (angle) from a gyroscope, which senses <a>angular velocity</a>, you need to
@@ -181,7 +181,7 @@ in hardware for known low frequency caused by adjacent hardware on the device.
 
 <dfn for="magnetometer">Magnetometers</dfn> are <i><a>magnetic field</a> sensors</i>, which means that without
 any strong magnetic influence close by, it will sense the Earth's <a>magnetic field</a>, which more or less points
-in the direction of North, but not true North. The <a>magnetometer interface</a> is defined in
+in the direction of North, but not true North. The <a>Magnetometer interface</a> is defined in
 [[MAGNETOMETER]] specification.
 
 As said, magnetometers are very sensitive to outside influence, like anything on a table that
@@ -189,16 +189,16 @@ has been slightly magnetized, and it is even affected by other things inside a d
 the device manufacturer can compensate for this somewhat. In practise though, these sensors
 work quite well for most common use-cases.
 
-As long as nothing that is magnetizes in the surrounding is moving around, then the magnetometer
+As long as nothing that is magnetized in the surrounding is moving around, the magnetometer
 readings are stable enough to be used to isolate gravity as mentioned above.
 
-Magnetometers are 3-axis sensors, which means that it gives a 3D vector pointing to the strongest
-<a>magnetic field</a>. This also means that they don't enforce a specific device orientation in order
+Magnetometer is a 3-axis sensor, which means it gives a 3D vector pointing to the strongest
+<a>magnetic field</a>. It also means that it does not enforce a specific device orientation in order
 to work.
 
 In order to tell how the device is being held, though, you need a gravity vector, which as a bare
-minimum requires an accelerometer, in the case of low pass filtering, and additionally a gyroscope
-if more precise readings are needed. This is called tilt compensation.
+minimum requires an accelerometer in the case of low pass filtering, and additionally a gyroscope
+if more precise readings are needed. This is called <dfn>tilt compensation</dfn>.
 
 The most common use-case for magnetometers are as part of sensor fusion, in order to generate an
 Orientation Sensor which is stationary to the Earth plane, or a compass, which is basically the
@@ -213,8 +213,8 @@ As mentioned above, each sensor has its own issues, such as noise and drift, and
 kind of compensation using input from a different sensor. Put another way, one sensor might not
 be very precise on its own, but the sum of multiple sensory input can be much more stable.
 
-Unfortunately, sensors require power, and the more sensors and the higher measuring frequency,
-the higher power consumption. The gyroscope is typically considered more power hungry than the
+Unfortunately, sensors require power, and the more sensors and the higher the measuring frequency,
+higher the power consumption. The gyroscope is typically considered more power hungry than the
 rest, as it needs to vibrate at a certain frequency in order to measure the <a>angular velocity</a>.
 
 For the above reasons, it is always important to consider the minimum set of sensors which
@@ -277,15 +277,15 @@ table, th, td {
 ## Low and high pass filters ## {#pass-filters}
 
 As mentioned earlier, it is possible to remove noise (high or low frequency) using 
-low and high pass filters. As the names say, the filters lets low or high frequencies
-pass and thus cuts of - or minimized the effect of unwanted frequences. 
+low and high pass filters. As the names say, the filters let low or high frequencies
+pass and thus cut of, or minimize, the effect of unwanted frequencies.
 
 ### Low-pass filter ### {#low-pass-filters}
 
 A common way to create a <dfn>low-pass filter</dfn> is to only use a percentage of
 the latest value and take the rest from the existing value. In a way this means that
 the filter remembers common values and thus smoothens out uncommon values which most
-often is a result of noise. As it uses a big percentage of the existing value, this
+often are a result of noise. As it uses a big percentage of the existing value, this
 solution introduces a delay in registering the actual events.
 
 <div class="example">
@@ -320,9 +320,9 @@ solution introduces a delay in registering the actual events.
 
 ### High-pass filter ### {#high-pass-filters}
 
-<dfn>High-pass filter</dfn> works like low-pass ones, but allows only high frequencies to pass through.
+<dfn>High-pass filter</dfn> works like a [=low-pass filter=], but allows only high frequencies to pass through.
 
-This can be useful in such cases like to get rid of the drift which builds up over time
+This can be useful to get rid of the drift which builds up over time
 with [=gyroscope=] readings.
 
 <div class="example">
@@ -363,7 +363,7 @@ with [=gyroscope=] readings.
 ## Orientation Sensor ## {#orientation}
 
 As mentioned before, the <dfn>Orientation Sensor</dfn>, is one of the common use-cases of a
-magnetometer, and it a sensor representing an orientation stationary (fixed to the magnetic
+[=magnetometer=], and is a sensor representing an orientation stationary (fixed to the magnetic
 field vector and gravity vector) to the Earth plane. The <a>OrientationSensor interface</a>
 is defined in [[ORIENTATION-SENSOR]] specification.
 
@@ -371,12 +371,12 @@ An orientation sensor can be useful for game controls such as a ball-in-a-maze p
 for a head-mounted display where you want to be able to rotate the display and look in all
 directions.
 
-As the reference frame of an orientation sensor is stationary, they are not useful as a
-controller for say a driving game on a phone, as they would not allow you to move around,
+As the reference frame of an orientation sensor is stationary, it is not useful as a
+controller for say a driving game on a phone, as it would not allow you to move around,
 even slightly or slowly, without affecting your driving direction.
 (See [=Relative Orientation Sensor=]).
 
-The orientation vector of the [=Orientation Sensor=], can be calculated the following way:
+The orientation vector of the [=Orientation Sensor=], can be calculated in the following way:
 
 As the [=Accelerometer=] is an <a>inertial-frame sensor</a>, the gravity vector will point
 towards the sky when the device is mostly stationary, and as long as the device is not in free fall,
@@ -388,40 +388,40 @@ the opposite direction as the gravity vector and generally be very unreliable.
 By taking the cross product between the the <a>magnetic field</a> vector and gravity vector
 (see [=Gravity Sensor=]), we get a vector which points East on the ground plane, using the right hand rule.
 
-Now if we take the cross product the gravity vector and the newly found East vector, then resulting
+Now if we take the cross product between the gravity vector and the newly found East vector, the resulting
 vector will point in the northern direction towards the Earth's <a>magnetic field</a>.
 
-The illustration below represents the case when device is at rest and y-axis points towards the
+The illustration below represents the case where the device is at rest and y-axis points towards the
 North. The reading from the [=Magnetometer=] is {x: 0, y: 11, z: -16} and [=Accelerometer=] reports
 {x: 0.11, y: 0.07, z: 9.81} <a>acceleration</a>. The uG is a unit vector representing the gravity,
-uB represents <a>magnetic field</a> vector, uE = uB × uG and points East. The uN = uG × uE that points to
+uB represents <a>magnetic field</a> vector, uE = uB × uG and points East. The uN = uG × uE points to
 the northern direction.
 
 <img src="orientation_fusion.png" srcset="orientation_fusion.svg" style="display: block;margin: auto;" alt="OrientationSensor fusion.">
 
-Thus an [=Orientation Sensor=] is a fusion sensor of the [=Magnetometer=] and the
+That means an [=Orientation Sensor=] is a fusion sensor of the [=Magnetometer=] and the
 [=Accelerometer=], and potentially the [=Gyroscope=] for better isolated gravity
 (see [=Gravity Sensor=]).
 
 
 ## Geomagnetic Orientation Sensor ## {#geomagnetic-orientation}
 
-A <dfn>Geomagnetic Orientation Sensor</dfn>, is a like the [=Orientation Sensor=], but
-doesn't use the [=Gyroscope=] which means that it uses less power. This also means that it
+A <dfn>Geomagnetic Orientation Sensor</dfn>, is like a [=Orientation Sensor=], but
+doesn't use the [=Gyroscope=] which means it uses less power. This also means that it
 is more sensitive to shakes and movement.
 
 As the main use-case for a [=Geomagnetic Orientation Sensor=] is to create a compass, or use
-compass direction within a mapping application, this is not much of a problem as people
+compass direction within a mapping application, this is not much of a problem since people
 usually hold the device steady for these use-cases.
 
 The actual <i>heading</i> (N, S, E, W) can be found by adjusting the rotation vector with
 the local <i>declination compensation</i> calculated from the current geolocation position.
 
 As the sensor uses the [=accelerometer=] to get a more steady heading, like when walking,
-the rotation vector is projected to the plane pendicular to the gravity vector (as isolated
-from the Accelerometer) which more or less represents the ground plane. This also means that
+the rotation vector is projected to the plane perpendicular to the gravity vector (as isolated
+from the [=accelerometer=]) which more or less represents the ground plane. This also means that
 if you are interested in the actual orientation of the gravity vector, then use the
-[=Magnetometer=] directly instead.
+[=magnetometer=] directly instead.
 
 
 ## Relative Orientation Sensor ## {#relative-orientation}
@@ -438,7 +438,7 @@ results and is easy to implement in hardware, this is a common solution.
 
 ### Complementary filter ### {#complementary-filters}
 
-A <dfn>complementary filter</dfn> can be thought of as a low and [=high-pass filter=] in one,
+A <dfn>complementary filter</dfn> can be thought of as a [=low-pass filter=] and [=high-pass filter=] in one,
 complementing the [=gyroscope=] values with the [=accelerometer=] values:
 
 θ<sub>n</sub> = α × (θ<sub>n-1</sub> + ω × ∂t) + (1.0 - α) × a
@@ -446,7 +446,7 @@ complementing the [=gyroscope=] values with the [=accelerometer=] values:
 With α being the weight constant, a the acceleration from [=accelerometer=], ω the angular
 velocity from [=gyroscope=] and ∂t being the time between measurements.
 
-A common value for 𝛼 is 0.98, which means that 98% of the weight lays on the [=gyroscope=]
+A common value for &alpha; is 0.98, which means that 98% of the weight lays on the [=gyroscope=]
 measurements.
 
 <div class="example">
@@ -458,18 +458,18 @@ measurements.
   position, so we need to use the [=accelerometer=], which includes gravity, to calibrate this
   to the ground plane.
 
-  The values from the [=accelerometer=] brings no information about the heading (alpha, the
+  The values from the [=accelerometer=] bring no information about the heading (alpha, the
   rotation around z), so we don't include that in our alpha component. On the other hand,
-  the [=accelerometer=] (due to gravity) provides info on how the device is held around
+  the [=accelerometer=] (due to gravity) provides information on how the device is held around
   the x and y axis (beta and gamma).
 
-  When there are no or little movements, the vector obtained from the [=accelerometer=]
-  reading, will contribute more to the (alpha, beta, gamma) angles than the [=gyroscope=].
+  When there is no or little movement, the vector obtained from the [=accelerometer=]
+  reading will contribute more to the (alpha, beta, gamma) angles than the [=gyroscope=].
 
-  As values from a steady [=accelerometer=] represents the gravity vector, and we don't
+  As values from a steady [=accelerometer=] represent the gravity vector, and we don't
   include the z component in the alpha, the result of this is that the orientation will
-  just follow the gyroscope and be stable. But as the origin of the heading depends on 
-  the device position at start this makes this a <i>device-relative orientation sensor</i>.
+  just follow the [=gyroscope=] and be stable. But as the origin of the heading depends on 
+  the device position at start this a <i>device-relative orientation sensor</i>.
 
     <pre highlight="js">
      const options = { frequency: 50 };
@@ -492,7 +492,7 @@ measurements.
         const norm = Math.sqrt(accl.x ** 2 + accl.y ** 2 + accl.z ** 2);
 
         // As we only can cover half (PI rad) of the full spectrum (2*PI rad) we multiply
-        // the unit vector with values from [-1, 1] with PI/2, covering [-PI/2, PI/2]
+        // the unit vector with values from [-1, 1] with PI/2, covering [-PI/2, PI/2].
         const scale = Math.PI / 2;
 
         alpha = alpha + gyro.z * dt;
@@ -510,7 +510,7 @@ measurements.
 <div class="example">
   An device-adjusting, relative orientation sensor.
 
-  From the above example, we notices that the alpha represented the initial heading
+  From the above example, we notice that the alpha represented the initial heading
   orientation. We also know that this heading might drift over time due to being
   based on the [=gyroscope=].
 
@@ -531,7 +531,7 @@ measurements.
   held more or less steady, the heading will move towards 0, meaning being adjusted to
   your current device position and not positioned according to the surroundings.
 
-  This shows how useful manual fusion can be at times.
+  This example shows how useful manual fusion can be at times.
 </div>
 
 ## Gravity and Linear Acceleration Sensor ## {#gravity-and-linear-acceleration}

--- a/index.bs
+++ b/index.bs
@@ -446,7 +446,7 @@ complementing the [=gyroscope=] values with the [=accelerometer=] values:
 With α being the weight constant, a the acceleration from [=accelerometer=], ω the angular
 velocity from [=gyroscope=] and ∂t being the time between measurements.
 
-A common value for &alpha; is 0.98, which means that 98% of the weight lays on the [=gyroscope=]
+A common value for α is 0.98, which means that 98% of the weight lays on the [=gyroscope=]
 measurements.
 
 <div class="example">

--- a/index.html
+++ b/index.html
@@ -1183,7 +1183,7 @@ Possible extra rowspan handling
       background-attachment: fixed;
     }
   </style>
-  <meta content="Bikeshed version a65093ce3e69a8d01029b4650499d152cd9bd39a" name="generator">
+  <meta content="Bikeshed version 7e43b56c4e1ede2eed18417e4d8def49e6eb4bd8" name="generator">
 <style>
 table {
   border-collapse: collapse;
@@ -1467,7 +1467,7 @@ table, th, td {
   <div class="p-summary" data-fill-with="abstract">
    <p>This explainer is an introduction to low-level and high-level motion sensors,
 
-their relation, inner workings and common use-cases. Common cases of event
+their relationship, inner workings and common use-cases. Common cases of event
 filtering and sensor fusion are introduced with examples, showing how to apply
 that on sensors following the Generic Sensor API specification.</p>
   </div>
@@ -1542,7 +1542,7 @@ that on sensors following the Generic Sensor API specification.</p>
    <p>There are a handful of different motion sensors available in modern hardware such
 as phones.</p>
    <p>The motion sensors extends the Generic Sensor API <a data-link-type="biblio" href="#biblio-generic-sensor">[GENERIC-SENSOR]</a> to expose
-a class of low-level and fusion sensors. This document explains the relation
+a class of low-level and fusion sensors. This document explains the relationship
 between these sensors.</p>
    <p>The low-level sensors include:</p>
    <ul>
@@ -1561,7 +1561,7 @@ beyond those described in the Generic Sensor API <a data-link-type="biblio" href
    <h2 class="heading settled" data-level="3" id="low-level-sensors"><span class="secno">3. </span><span class="content">Low-level Sensors</span><a class="self-link" href="#low-level-sensors"></a></h2>
    <h3 class="heading settled" data-level="3.1" id="accelerometer-sensor"><span class="secno">3.1. </span><span class="content">Accelerometer</span><a class="self-link" href="#accelerometer-sensor"></a></h3>
    <p>A raw <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="accelerometer">accelerometer</dfn> sensor measures changes in acceleration in 3 different
-directions, but is affected by <i>gravity</i>. The <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#accelerometer-interface">accelerometer interface</a> is defined in <a data-link-type="biblio" href="#biblio-accelerometer">[ACCELEROMETER]</a> specification.</p>
+directions, but is affected by <i>gravity</i>. The <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#accelerometer-interface">Accelerometer interface</a> is defined in <a data-link-type="biblio" href="#biblio-accelerometer">[ACCELEROMETER]</a> specification.</p>
    <p>The <a data-link-type="dfn" href="#accelerometer" id="ref-for-accelerometer-2">Accelerometer</a> sensor is an <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="inertial-frame-sensor">inertial-frame sensor</dfn>, this means that when the device
 is in free fall, the acceleration is 0 m/s<sup>2</sup> in the falling direction, and
 when a device is laying flat on a table, the acceleration in upwards direction will be equal
@@ -1577,7 +1577,7 @@ kinds of sensor fusion like creating a magnetic compass.</p>
    <p>For acceleration, you usually care about the big changes and want to avoid noise, like the
 gravity, thus a <a data-link-type="dfn" href="#high-pass-filter" id="ref-for-high-pass-filter-1">high-pass filter</a> can help isolate the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#linear-acceleration">linear acceleration</a> and a <a data-link-type="dfn" href="#low-pass-filter" id="ref-for-low-pass-filter-1">low-pass
 filter</a> can help isolate the gravity. A <a data-link-type="dfn" href="#low-pass-filter" id="ref-for-low-pass-filter-2">low-pass filter</a> can thus be useful for measuring a
-tilt. Unfortunately any high or <a data-link-type="dfn" href="#low-pass-filter" id="ref-for-low-pass-filter-3">low-pass filter</a> introduced a delay, which may or may not be
+tilt. Unfortunately, any <a data-link-type="dfn" href="#high-pass-filter" id="ref-for-high-pass-filter-2">high-pass filter</a> or <a data-link-type="dfn" href="#low-pass-filter" id="ref-for-low-pass-filter-3">low-pass filter</a> introduces a delay, which may or may not be
 acceptable.</p>
    <p>Notice, as accelerometers report <i>acceleration</i>, you need to integrate to get <i>velocity</i>:</p>
    <p>v = ∫a×∂t</p>
@@ -1587,11 +1587,11 @@ acceptable.</p>
    <p>a = g×sin(θ), x = ½×at<sup>2</sup></p>
    <p>So position from an accelerometer is very imprecise and not very useful.</p>
    <h3 class="heading settled" data-level="3.2" id="gyroscope-sensor"><span class="secno">3.2. </span><span class="content">Gyroscope</span><a class="self-link" href="#gyroscope-sensor"></a></h3>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="gyroscope">gyroscope</dfn> senses <i><a data-link-type="dfn" href="https://w3c.github.io/gyroscope#angular-velocity">angular velocity</a></i>, relative to itself, thus they measure their own rotation,
-using something called the Coriolis effect. Gyroscopes oscillate at relative high frequency in
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="gyroscope">gyroscope</dfn> senses <i><a data-link-type="dfn" href="https://w3c.github.io/gyroscope#angular-velocity">angular velocity</a></i>, relative to itself, thus it measures its own rotation,
+using an inertial force called the Coriolis effect. Gyroscopes oscillate at relative high frequency in
 order to measure this and are thus one of the most power hungry motion sensors. This also means
-that they can easily be effected by other vibrations, like a vibration (rumble) motor or speaker
-on the same device. The <a data-link-type="dfn" href="https://w3c.github.io/gyroscope#gyroscope-interface">gyroscope interface</a> is defined in <a data-link-type="biblio" href="#biblio-gyroscope">[GYROSCOPE]</a> specification.</p>
+that they can easily be affected by other vibrations, like a vibration (rumble) motor or speaker
+on the same device. The <a data-link-type="dfn" href="https://w3c.github.io/gyroscope#gyroscope-interface">Gyroscope interface</a> is defined in <a data-link-type="biblio" href="#biblio-gyroscope">[GYROSCOPE]</a> specification.</p>
    <p>In order to get rotation (angle) from a gyroscope, which senses <a data-link-type="dfn" href="https://w3c.github.io/gyroscope#angular-velocity">angular velocity</a>, you need to
 perform a single integration.</p>
    <p>f ≡ frequency</p>
@@ -1608,18 +1608,18 @@ meaning the gyroscope will drift over time.</p>
    <h3 class="heading settled" data-level="3.3" id="magnetometer-sensor"><span class="secno">3.3. </span><span class="content">Magnetometer</span><a class="self-link" href="#magnetometer-sensor"></a></h3>
    <p><dfn class="dfn-paneled" data-dfn-for="magnetometer" data-dfn-type="dfn" data-noexport="" id="magnetometer-magnetometers">Magnetometers</dfn> are <i><a data-link-type="dfn" href="https://w3c.github.io/magnetometer#magnetic-field">magnetic field</a> sensors</i>, which means that without
 any strong magnetic influence close by, it will sense the Earth’s <a data-link-type="dfn" href="https://w3c.github.io/magnetometer#magnetic-field">magnetic field</a>, which more or less points
-in the direction of North, but not true North. The <a data-link-type="dfn" href="https://w3c.github.io/magnetometer#magnetometer-interface">magnetometer interface</a> is defined in <a data-link-type="biblio" href="#biblio-magnetometer">[MAGNETOMETER]</a> specification.</p>
+in the direction of North, but not true North. The <a data-link-type="dfn" href="https://w3c.github.io/magnetometer#magnetometer-interface">Magnetometer interface</a> is defined in <a data-link-type="biblio" href="#biblio-magnetometer">[MAGNETOMETER]</a> specification.</p>
    <p>As said, magnetometers are very sensitive to outside influence, like anything on a table that
 has been slightly magnetized, and it is even affected by other things inside a device, though
 the device manufacturer can compensate for this somewhat. In practise though, these sensors
 work quite well for most common use-cases.</p>
-   <p>As long as nothing that is magnetizes in the surrounding is moving around, then the magnetometer
+   <p>As long as nothing that is magnetized in the surrounding is moving around, the magnetometer
 readings are stable enough to be used to isolate gravity as mentioned above.</p>
-   <p>Magnetometers are 3-axis sensors, which means that it gives a 3D vector pointing to the strongest <a data-link-type="dfn" href="https://w3c.github.io/magnetometer#magnetic-field">magnetic field</a>. This also means that they don’t enforce a specific device orientation in order
+   <p>Magnetometer is a 3-axis sensor, which means it gives a 3D vector pointing to the strongest <a data-link-type="dfn" href="https://w3c.github.io/magnetometer#magnetic-field">magnetic field</a>. It also means that it does not enforce a specific device orientation in order
 to work.</p>
    <p>In order to tell how the device is being held, though, you need a gravity vector, which as a bare
-minimum requires an accelerometer, in the case of low pass filtering, and additionally a gyroscope
-if more precise readings are needed. This is called tilt compensation.</p>
+minimum requires an accelerometer in the case of low pass filtering, and additionally a gyroscope
+if more precise readings are needed. This is called <dfn data-dfn-type="dfn" data-noexport="" id="tilt-compensation">tilt compensation<a class="self-link" href="#tilt-compensation"></a></dfn>.</p>
    <p>The most common use-case for magnetometers are as part of sensor fusion, in order to generate an
 Orientation Sensor which is stationary to the Earth plane, or a compass, which is basically the
 former with corrections to the declination depending on geolocation position, such that it points
@@ -1628,8 +1628,8 @@ to the true North.</p>
    <p>As mentioned above, each sensor has its own issues, such as noise and drift, and often need some
 kind of compensation using input from a different sensor. Put another way, one sensor might not
 be very precise on its own, but the sum of multiple sensory input can be much more stable.</p>
-   <p>Unfortunately, sensors require power, and the more sensors and the higher measuring frequency,
-the higher power consumption. The gyroscope is typically considered more power hungry than the
+   <p>Unfortunately, sensors require power, and the more sensors and the higher the measuring frequency,
+higher the power consumption. The gyroscope is typically considered more power hungry than the
 rest, as it needs to vibrate at a certain frequency in order to measure the <a data-link-type="dfn" href="https://w3c.github.io/gyroscope#angular-velocity">angular velocity</a>.</p>
    <p>For the above reasons, it is always important to consider the minimum set of sensors which
 solves a task satisfactory. As many devices today can do certain kinds of sensor fusion in
@@ -1664,13 +1664,13 @@ hardware, it most often makes sense to use these from a power and performance po
    </table>
    <h3 class="heading settled" data-level="4.2" id="pass-filters"><span class="secno">4.2. </span><span class="content">Low and high pass filters</span><a class="self-link" href="#pass-filters"></a></h3>
    <p>As mentioned earlier, it is possible to remove noise (high or low frequency) using
-low and high pass filters. As the names say, the filters lets low or high frequencies
-pass and thus cuts of - or minimized the effect of unwanted frequences.</p>
+low and high pass filters. As the names say, the filters let low or high frequencies
+pass and thus cut of, or minimize, the effect of unwanted frequencies.</p>
    <h4 class="heading settled" data-level="4.2.1" id="low-pass-filters"><span class="secno">4.2.1. </span><span class="content">Low-pass filter</span><a class="self-link" href="#low-pass-filters"></a></h4>
    <p>A common way to create a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="low-pass-filter">low-pass filter</dfn> is to only use a percentage of
 the latest value and take the rest from the existing value. In a way this means that
 the filter remembers common values and thus smoothens out uncommon values which most
-often is a result of noise. As it uses a big percentage of the existing value, this
+often are a result of noise. As it uses a big percentage of the existing value, this
 solution introduces a delay in registering the actual events.</p>
    <div class="example" id="example-f644befe">
     <a class="self-link" href="#example-f644befe"></a> 
@@ -1692,7 +1692,7 @@ solution introduces a delay in registering the actual events.</p>
 <span class="c1">// Isolate gravity with low-pass filter.
 </span><span class="kr">const</span> filter <span class="o">=</span> <span class="k">new</span> LowPassFilterData<span class="p">(</span>accl<span class="p">,</span> <span class="mf">0.8</span><span class="p">)</span><span class="p">;</span>
 
-accl<span class="p">.</span>onchange <span class="o">=</span> <span class="p">(</span><span class="p">)</span> <span class="p">=></span> <span class="p">{</span>
+accl<span class="p">.</span>onchange <span class="o">=</span> <span class="p">(</span><span class="p">)</span> <span class="o">=></span> <span class="p">{</span>
   filter<span class="p">.</span>update<span class="p">(</span>accl<span class="p">)</span><span class="p">;</span> <span class="c1">// Pass latest values through filter.
 </span>  console<span class="p">.</span>log<span class="p">(</span><span class="sb">`</span><span class="sb">Isolated gravity (</span><span class="si">${</span>filter<span class="p">.</span>x<span class="si">}</span><span class="sb">, </span><span class="si">${</span>filter<span class="p">.</span>y<span class="si">}</span><span class="sb">, </span><span class="si">${</span>filter<span class="p">.</span>z<span class="si">}</span><span class="sb">)</span><span class="sb">`</span><span class="p">)</span><span class="p">;</span>
 <span class="p">}</span>
@@ -1701,8 +1701,8 @@ accl<span class="p">.</span>start<span class="p">(</span><span class="p">)</span
 </pre>
    </div>
    <h4 class="heading settled" data-level="4.2.2" id="high-pass-filters"><span class="secno">4.2.2. </span><span class="content">High-pass filter</span><a class="self-link" href="#high-pass-filters"></a></h4>
-   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="high-pass-filter">High-pass filter</dfn> works like low-pass ones, but allows only high frequencies to pass through.</p>
-   <p>This can be useful in such cases like to get rid of the drift which builds up over time
+   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="high-pass-filter">High-pass filter</dfn> works like a <a data-link-type="dfn" href="#low-pass-filter" id="ref-for-low-pass-filter-4">low-pass filter</a>, but allows only high frequencies to pass through.</p>
+   <p>This can be useful to get rid of the drift which builds up over time
 with <a data-link-type="dfn" href="#gyroscope" id="ref-for-gyroscope-7">gyroscope</a> readings.</p>
    <div class="example" id="example-b6892c3a">
     <a class="self-link" href="#example-b6892c3a"></a> 
@@ -1729,7 +1729,7 @@ with <a data-link-type="dfn" href="#gyroscope" id="ref-for-gyroscope-7">gyroscop
 <span class="c1">// Remove drift with a  high pass filter.
 </span><span class="kr">const</span> filter <span class="o">=</span> <span class="k">new</span> HighPassFilterData<span class="p">(</span>gyro<span class="p">,</span> <span class="mf">0.8</span><span class="p">)</span><span class="p">;</span>
 
-gyro<span class="p">.</span>onchange <span class="o">=</span> <span class="p">(</span><span class="p">)</span> <span class="p">=></span> <span class="p">{</span>
+gyro<span class="p">.</span>onchange <span class="o">=</span> <span class="p">(</span><span class="p">)</span> <span class="o">=></span> <span class="p">{</span>
   filter<span class="p">.</span>update<span class="p">(</span>gyro<span class="p">)</span><span class="p">;</span> <span class="c1">// Pass latest values through filter.
 </span>  console<span class="p">.</span>log<span class="p">(</span><span class="sb">`</span><span class="sb">Steady gyroscope (</span><span class="si">${</span>filter<span class="p">.</span>x<span class="si">}</span><span class="sb">, </span><span class="si">${</span>filter<span class="p">.</span>y<span class="si">}</span><span class="sb">, </span><span class="si">${</span>filter<span class="p">.</span>z<span class="si">}</span><span class="sb">)</span><span class="sb">`</span><span class="p">)</span><span class="p">;</span>
 <span class="p">}</span>
@@ -1738,17 +1738,16 @@ gyro<span class="p">.</span>start<span class="p">(</span><span class="p">)</span
 </pre>
    </div>
    <h3 class="heading settled" data-level="4.3" id="orientation"><span class="secno">4.3. </span><span class="content">Orientation Sensor</span><a class="self-link" href="#orientation"></a></h3>
-   <p>As mentioned before, the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="orientation-sensor">Orientation Sensor</dfn>, is one of the common use-cases of a
-magnetometer, and it a sensor representing an orientation stationary (fixed to the magnetic
+   <p>As mentioned before, the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="orientation-sensor">Orientation Sensor</dfn>, is one of the common use-cases of a <a data-link-type="dfn" href="#magnetometer-magnetometers" id="ref-for-magnetometer-magnetometers-6">magnetometer</a>, and is a sensor representing an orientation stationary (fixed to the magnetic
 field vector and gravity vector) to the Earth plane. The <a data-link-type="dfn" href="https://w3c.github.io/orientation-sensor#orientationsensor-interface">OrientationSensor interface</a> is defined in <span>[ORIENTATION-SENSOR]</span> specification.</p>
    <p>An orientation sensor can be useful for game controls such as a ball-in-a-maze puzzle, or
 for a head-mounted display where you want to be able to rotate the display and look in all
 directions.</p>
-   <p>As the reference frame of an orientation sensor is stationary, they are not useful as a
-controller for say a driving game on a phone, as they would not allow you to move around,
+   <p>As the reference frame of an orientation sensor is stationary, it is not useful as a
+controller for say a driving game on a phone, as it would not allow you to move around,
 even slightly or slowly, without affecting your driving direction.
 (See <a data-link-type="dfn" href="#relative-orientation-sensor" id="ref-for-relative-orientation-sensor-2">Relative Orientation Sensor</a>).</p>
-   <p>The orientation vector of the <a data-link-type="dfn" href="#orientation-sensor" id="ref-for-orientation-sensor-2">Orientation Sensor</a>, can be calculated the following way:</p>
+   <p>The orientation vector of the <a data-link-type="dfn" href="#orientation-sensor" id="ref-for-orientation-sensor-2">Orientation Sensor</a>, can be calculated in the following way:</p>
    <p>As the <a data-link-type="dfn" href="#accelerometer" id="ref-for-accelerometer-8">Accelerometer</a> is an <a data-link-type="dfn" href="#inertial-frame-sensor" id="ref-for-inertial-frame-sensor-1">inertial-frame sensor</a>, the gravity vector will point
 towards the sky when the device is mostly stationary, and as long as the device is not in free fall,
 there is enough vector length to project the <a data-link-type="dfn" href="https://w3c.github.io/magnetometer#magnetic-field">magnetic field</a> vector onto the ground plane.</p>
@@ -1756,58 +1755,58 @@ there is enough vector length to project the <a data-link-type="dfn" href="https
 the opposite direction as the gravity vector and generally be very unreliable.</p>
    <p>By taking the cross product between the the <a data-link-type="dfn" href="https://w3c.github.io/magnetometer#magnetic-field">magnetic field</a> vector and gravity vector
 (see <a data-link-type="dfn" href="#gravity-sensor" id="ref-for-gravity-sensor-3">Gravity Sensor</a>), we get a vector which points East on the ground plane, using the right hand rule.</p>
-   <p>Now if we take the cross product the gravity vector and the newly found East vector, then resulting
+   <p>Now if we take the cross product between the gravity vector and the newly found East vector, the resulting
 vector will point in the northern direction towards the Earth’s <a data-link-type="dfn" href="https://w3c.github.io/magnetometer#magnetic-field">magnetic field</a>.</p>
-   <p>The illustration below represents the case when device is at rest and y-axis points towards the
-North. The reading from the <a data-link-type="dfn" href="#magnetometer-magnetometers" id="ref-for-magnetometer-magnetometers-6">Magnetometer</a> is {x: 0, y: 11, z: -16} and <a data-link-type="dfn" href="#accelerometer" id="ref-for-accelerometer-9">Accelerometer</a> reports
+   <p>The illustration below represents the case where the device is at rest and y-axis points towards the
+North. The reading from the <a data-link-type="dfn" href="#magnetometer-magnetometers" id="ref-for-magnetometer-magnetometers-7">Magnetometer</a> is {x: 0, y: 11, z: -16} and <a data-link-type="dfn" href="#accelerometer" id="ref-for-accelerometer-9">Accelerometer</a> reports
 {x: 0.11, y: 0.07, z: 9.81} <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#acceleration">acceleration</a>. The uG is a unit vector representing the gravity,
-uB represents <a data-link-type="dfn" href="https://w3c.github.io/magnetometer#magnetic-field">magnetic field</a> vector, uE = uB × uG and points East. The uN = uG × uE that points to
+uB represents <a data-link-type="dfn" href="https://w3c.github.io/magnetometer#magnetic-field">magnetic field</a> vector, uE = uB × uG and points East. The uN = uG × uE points to
 the northern direction.</p>
    <p><img alt="OrientationSensor fusion." src="orientation_fusion.png" srcset="orientation_fusion.svg" style="display: block;margin: auto;"></p>
-   <p>Thus an <a data-link-type="dfn" href="#orientation-sensor" id="ref-for-orientation-sensor-3">Orientation Sensor</a> is a fusion sensor of the <a data-link-type="dfn" href="#magnetometer-magnetometers" id="ref-for-magnetometer-magnetometers-7">Magnetometer</a> and the <a data-link-type="dfn" href="#accelerometer" id="ref-for-accelerometer-10">Accelerometer</a>, and potentially the <a data-link-type="dfn" href="#gyroscope" id="ref-for-gyroscope-8">Gyroscope</a> for better isolated gravity
+   <p>That means an <a data-link-type="dfn" href="#orientation-sensor" id="ref-for-orientation-sensor-3">Orientation Sensor</a> is a fusion sensor of the <a data-link-type="dfn" href="#magnetometer-magnetometers" id="ref-for-magnetometer-magnetometers-8">Magnetometer</a> and the <a data-link-type="dfn" href="#accelerometer" id="ref-for-accelerometer-10">Accelerometer</a>, and potentially the <a data-link-type="dfn" href="#gyroscope" id="ref-for-gyroscope-8">Gyroscope</a> for better isolated gravity
 (see <a data-link-type="dfn" href="#gravity-sensor" id="ref-for-gravity-sensor-4">Gravity Sensor</a>).</p>
    <h3 class="heading settled" data-level="4.4" id="geomagnetic-orientation"><span class="secno">4.4. </span><span class="content">Geomagnetic Orientation Sensor</span><a class="self-link" href="#geomagnetic-orientation"></a></h3>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="geomagnetic-orientation-sensor">Geomagnetic Orientation Sensor</dfn>, is a like the <a data-link-type="dfn" href="#orientation-sensor" id="ref-for-orientation-sensor-4">Orientation Sensor</a>, but
-doesn’t use the <a data-link-type="dfn" href="#gyroscope" id="ref-for-gyroscope-9">Gyroscope</a> which means that it uses less power. This also means that it
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="geomagnetic-orientation-sensor">Geomagnetic Orientation Sensor</dfn>, is like a <a data-link-type="dfn" href="#orientation-sensor" id="ref-for-orientation-sensor-4">Orientation Sensor</a>, but
+doesn’t use the <a data-link-type="dfn" href="#gyroscope" id="ref-for-gyroscope-9">Gyroscope</a> which means it uses less power. This also means that it
 is more sensitive to shakes and movement.</p>
    <p>As the main use-case for a <a data-link-type="dfn" href="#geomagnetic-orientation-sensor" id="ref-for-geomagnetic-orientation-sensor-2">Geomagnetic Orientation Sensor</a> is to create a compass, or use
-compass direction within a mapping application, this is not much of a problem as people
+compass direction within a mapping application, this is not much of a problem since people
 usually hold the device steady for these use-cases.</p>
    <p>The actual <i>heading</i> (N, S, E, W) can be found by adjusting the rotation vector with
 the local <i>declination compensation</i> calculated from the current geolocation position.</p>
    <p>As the sensor uses the <a data-link-type="dfn" href="#accelerometer" id="ref-for-accelerometer-11">accelerometer</a> to get a more steady heading, like when walking,
-the rotation vector is projected to the plane pendicular to the gravity vector (as isolated
-from the Accelerometer) which more or less represents the ground plane. This also means that
-if you are interested in the actual orientation of the gravity vector, then use the <a data-link-type="dfn" href="#magnetometer-magnetometers" id="ref-for-magnetometer-magnetometers-8">Magnetometer</a> directly instead.</p>
+the rotation vector is projected to the plane perpendicular to the gravity vector (as isolated
+from the <a data-link-type="dfn" href="#accelerometer" id="ref-for-accelerometer-12">accelerometer</a>) which more or less represents the ground plane. This also means that
+if you are interested in the actual orientation of the gravity vector, then use the <a data-link-type="dfn" href="#magnetometer-magnetometers" id="ref-for-magnetometer-magnetometers-9">magnetometer</a> directly instead.</p>
    <h3 class="heading settled" data-level="4.5" id="relative-orientation"><span class="secno">4.5. </span><span class="content">Relative Orientation Sensor</span><a class="self-link" href="#relative-orientation"></a></h3>
-   <p>On most sensor hubs, gravity is isolated from the <a data-link-type="dfn" href="#accelerometer" id="ref-for-accelerometer-12">accelerometer</a> using the <a data-link-type="dfn" href="#gyroscope" id="ref-for-gyroscope-10">gyroscope</a>,
-and the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#linear-acceleration">linear acceleration</a> is isolated by removing the isolated gravity, from the <a data-link-type="dfn" href="#accelerometer" id="ref-for-accelerometer-13">accelerometer</a> values.</p>
+   <p>On most sensor hubs, gravity is isolated from the <a data-link-type="dfn" href="#accelerometer" id="ref-for-accelerometer-13">accelerometer</a> using the <a data-link-type="dfn" href="#gyroscope" id="ref-for-gyroscope-10">gyroscope</a>,
+and the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#linear-acceleration">linear acceleration</a> is isolated by removing the isolated gravity, from the <a data-link-type="dfn" href="#accelerometer" id="ref-for-accelerometer-14">accelerometer</a> values.</p>
    <p>This avoids the delay which low and high pass filters introduce.</p>
    <p>One way of doing this is using a Kalman filter or <a data-link-type="dfn" href="#complementary-filter" id="ref-for-complementary-filter-1">complementary filter</a>, which leads us to
 the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="relative-orientation-sensor">Relative Orientation Sensor</dfn>. As a <a data-link-type="dfn" href="#complementary-filter" id="ref-for-complementary-filter-2">complementary filter</a> yields quite good
 results and is easy to implement in hardware, this is a common solution.</p>
    <h4 class="heading settled" data-level="4.5.1" id="complementary-filters"><span class="secno">4.5.1. </span><span class="content">Complementary filter</span><a class="self-link" href="#complementary-filters"></a></h4>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="complementary-filter">complementary filter</dfn> can be thought of as a low and <a data-link-type="dfn" href="#high-pass-filter" id="ref-for-high-pass-filter-2">high-pass filter</a> in one,
-complementing the <a data-link-type="dfn" href="#gyroscope" id="ref-for-gyroscope-11">gyroscope</a> values with the <a data-link-type="dfn" href="#accelerometer" id="ref-for-accelerometer-14">accelerometer</a> values:</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="complementary-filter">complementary filter</dfn> can be thought of as a <a data-link-type="dfn" href="#low-pass-filter" id="ref-for-low-pass-filter-5">low-pass filter</a> and <a data-link-type="dfn" href="#high-pass-filter" id="ref-for-high-pass-filter-3">high-pass filter</a> in one,
+complementing the <a data-link-type="dfn" href="#gyroscope" id="ref-for-gyroscope-11">gyroscope</a> values with the <a data-link-type="dfn" href="#accelerometer" id="ref-for-accelerometer-15">accelerometer</a> values:</p>
    <p>θ<sub>n</sub> = α × (θ<sub>n-1</sub> + ω × ∂t) + (1.0 - α) × a</p>
-   <p>With α being the weight constant, a the acceleration from <a data-link-type="dfn" href="#accelerometer" id="ref-for-accelerometer-15">accelerometer</a>, ω the angular
+   <p>With α being the weight constant, a the acceleration from <a data-link-type="dfn" href="#accelerometer" id="ref-for-accelerometer-16">accelerometer</a>, ω the angular
 velocity from <a data-link-type="dfn" href="#gyroscope" id="ref-for-gyroscope-12">gyroscope</a> and ∂t being the time between measurements.</p>
-   <p>A common value for 𝛼 is 0.98, which means that 98% of the weight lays on the <a data-link-type="dfn" href="#gyroscope" id="ref-for-gyroscope-13">gyroscope</a> measurements.</p>
-   <div class="example" id="example-7af818b7">
-    <a class="self-link" href="#example-7af818b7"></a> Manually calculate the relative orientation in Euler angles (radian) using a <a data-link-type="dfn" href="#complementary-filter" id="ref-for-complementary-filter-3">complementary filter</a>. 
+   <p>A common value for α is 0.98, which means that 98% of the weight lays on the <a data-link-type="dfn" href="#gyroscope" id="ref-for-gyroscope-13">gyroscope</a> measurements.</p>
+   <div class="example" id="example-e1667a72">
+    <a class="self-link" href="#example-e1667a72"></a> Manually calculate the relative orientation in Euler angles (radian) using a <a data-link-type="dfn" href="#complementary-filter" id="ref-for-complementary-filter-3">complementary filter</a>. 
     <p>The <a data-link-type="dfn" href="#gyroscope" id="ref-for-gyroscope-14">gyroscope</a> measures <i><a data-link-type="dfn" href="https://w3c.github.io/gyroscope#angular-velocity">angular velocity</a></i>, so by multiplying with the time difference,
   we get the <i>change of angle</i>. This change is always calculated relative to the current device
-  position, so we need to use the <a data-link-type="dfn" href="#accelerometer" id="ref-for-accelerometer-16">accelerometer</a>, which includes gravity, to calibrate this
+  position, so we need to use the <a data-link-type="dfn" href="#accelerometer" id="ref-for-accelerometer-17">accelerometer</a>, which includes gravity, to calibrate this
   to the ground plane.</p>
-    <p>The values from the <a data-link-type="dfn" href="#accelerometer" id="ref-for-accelerometer-17">accelerometer</a> brings no information about the heading (alpha, the
+    <p>The values from the <a data-link-type="dfn" href="#accelerometer" id="ref-for-accelerometer-18">accelerometer</a> bring no information about the heading (alpha, the
   rotation around z), so we don’t include that in our alpha component. On the other hand,
-  the <a data-link-type="dfn" href="#accelerometer" id="ref-for-accelerometer-18">accelerometer</a> (due to gravity) provides info on how the device is held around
+  the <a data-link-type="dfn" href="#accelerometer" id="ref-for-accelerometer-19">accelerometer</a> (due to gravity) provides information on how the device is held around
   the x and y axis (beta and gamma).</p>
-    <p>When there are no or little movements, the vector obtained from the <a data-link-type="dfn" href="#accelerometer" id="ref-for-accelerometer-19">accelerometer</a> reading, will contribute more to the (alpha, beta, gamma) angles than the <a data-link-type="dfn" href="#gyroscope" id="ref-for-gyroscope-15">gyroscope</a>.</p>
-    <p>As values from a steady <a data-link-type="dfn" href="#accelerometer" id="ref-for-accelerometer-20">accelerometer</a> represents the gravity vector, and we don’t
+    <p>When there is no or little movement, the vector obtained from the <a data-link-type="dfn" href="#accelerometer" id="ref-for-accelerometer-20">accelerometer</a> reading will contribute more to the (alpha, beta, gamma) angles than the <a data-link-type="dfn" href="#gyroscope" id="ref-for-gyroscope-15">gyroscope</a>.</p>
+    <p>As values from a steady <a data-link-type="dfn" href="#accelerometer" id="ref-for-accelerometer-21">accelerometer</a> represent the gravity vector, and we don’t
   include the z component in the alpha, the result of this is that the orientation will
-  just follow the gyroscope and be stable. But as the origin of the heading depends on 
-  the device position at start this makes this a <i>device-relative orientation sensor</i>.</p>
+  just follow the <a data-link-type="dfn" href="#gyroscope" id="ref-for-gyroscope-16">gyroscope</a> and be stable. But as the origin of the heading depends on 
+  the device position at start this a <i>device-relative orientation sensor</i>.</p>
 <pre class="highlight"><span class="kr">const</span> options <span class="o">=</span> <span class="p">{</span> frequency<span class="o">:</span> <span class="mi">50</span> <span class="p">}</span><span class="p">;</span>
 
 <span class="kr">const</span> accl <span class="o">=</span> <span class="k">new</span> Accelerometer<span class="p">(</span>options<span class="p">)</span><span class="p">;</span>
@@ -1817,7 +1816,7 @@ velocity from <a data-link-type="dfn" href="#gyroscope" id="ref-for-gyroscope-12
 <span class="kd">let</span> alpha <span class="o">=</span> beta <span class="o">=</span> gamma <span class="o">=</span> <span class="mi">0</span><span class="p">;</span>
 <span class="kr">const</span> bias <span class="o">=</span> <span class="mf">0.98</span><span class="p">;</span>
 
-gyro<span class="p">.</span>onchange <span class="o">=</span> <span class="p">(</span><span class="p">)</span> <span class="p">=></span> <span class="p">{</span>
+gyro<span class="p">.</span>onchange <span class="o">=</span> <span class="p">(</span><span class="p">)</span> <span class="o">=></span> <span class="p">{</span>
    <span class="kd">let</span> dt <span class="o">=</span> timestamp <span class="o">?</span> <span class="p">(</span>gyro<span class="p">.</span>timestamp <span class="o">-</span> timestamp<span class="p">)</span> <span class="o">/</span> <span class="mi">1000</span> <span class="o">:</span> <span class="mi">0</span><span class="p">;</span>
    timestamp <span class="o">=</span> gyro<span class="p">.</span>timestamp<span class="p">;</span>
 
@@ -1828,7 +1827,7 @@ gyro<span class="p">.</span>onchange <span class="o">=</span> <span class="p">(<
 </span>   <span class="kr">const</span> norm <span class="o">=</span> Math<span class="p">.</span>sqrt<span class="p">(</span>accl<span class="p">.</span>x <span class="o">*</span><span class="o">*</span> <span class="mi">2</span> <span class="o">+</span> accl<span class="p">.</span>y <span class="o">*</span><span class="o">*</span> <span class="mi">2</span> <span class="o">+</span> accl<span class="p">.</span>z <span class="o">*</span><span class="o">*</span> <span class="mi">2</span><span class="p">)</span><span class="p">;</span>
 
    <span class="c1">// As we only can cover half (PI rad) of the full spectrum (2*PI rad) we multiply
-</span>   <span class="c1">// the unit vector with values from [-1, 1] with PI/2, covering [-PI/2, PI/2]
+</span>   <span class="c1">// the unit vector with values from [-1, 1] with PI/2, covering [-PI/2, PI/2].
 </span>   <span class="kr">const</span> scale <span class="o">=</span> Math<span class="p">.</span>PI <span class="o">/</span> <span class="mi">2</span><span class="p">;</span>
 
    alpha <span class="o">=</span> alpha <span class="o">+</span> gyro<span class="p">.</span>z <span class="o">*</span> dt<span class="p">;</span>
@@ -1842,11 +1841,11 @@ gyro<span class="p">.</span>onchange <span class="o">=</span> <span class="p">(<
  gyro<span class="p">.</span>start<span class="p">(</span><span class="p">)</span><span class="p">;</span>
 </pre>
    </div>
-   <div class="example" id="example-4fbc3615">
-    <a class="self-link" href="#example-4fbc3615"></a> An device-adjusting, relative orientation sensor. 
-    <p>From the above example, we notices that the alpha represented the initial heading
+   <div class="example" id="example-ae6c2246">
+    <a class="self-link" href="#example-ae6c2246"></a> An device-adjusting, relative orientation sensor. 
+    <p>From the above example, we notice that the alpha represented the initial heading
   orientation. We also know that this heading might drift over time due to being
-  based on the <a data-link-type="dfn" href="#gyroscope" id="ref-for-gyroscope-16">gyroscope</a>.</p>
+  based on the <a data-link-type="dfn" href="#gyroscope" id="ref-for-gyroscope-17">gyroscope</a>.</p>
     <p>In some situations you might want the orientation to drift towards your current
   position. This can be useful for a controller inside a virtual reality
   environment, where you want a car to follow the heading of your controller, but you
@@ -1859,13 +1858,13 @@ alpha <span class="o">=</span> <span class="p">(</span><span class="mi">1</span>
     <p>With the above 2% of the alpha consists of the value 0. Thus, when the device is being
   held more or less steady, the heading will move towards 0, meaning being adjusted to
   your current device position and not positioned according to the surroundings.</p>
-    <p>This shows how useful manual fusion can be at times.</p>
+    <p>This example shows how useful manual fusion can be at times.</p>
    </div>
    <h3 class="heading settled" data-level="4.6" id="gravity-and-linear-acceleration"><span class="secno">4.6. </span><span class="content">Gravity and Linear Acceleration Sensor</span><a class="self-link" href="#gravity-and-linear-acceleration"></a></h3>
    <p>The <a data-link-type="dfn" href="#complementary-filter" id="ref-for-complementary-filter-4">complementary filter</a> used above is quite good at isolating the gravity, and most sensor
-hubs thus isolate <i>gravity</i> from the <a data-link-type="dfn" href="#accelerometer" id="ref-for-accelerometer-21">accelerometer</a> using the <a data-link-type="dfn" href="#gyroscope" id="ref-for-gyroscope-17">gyroscope</a>, and the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#linear-acceleration">linear acceleration</a> is isolated by removing the isolated gravity, from the <a data-link-type="dfn" href="#accelerometer" id="ref-for-accelerometer-22">accelerometer</a> values.</p>
+hubs thus isolate <i>gravity</i> from the <a data-link-type="dfn" href="#accelerometer" id="ref-for-accelerometer-22">accelerometer</a> using the <a data-link-type="dfn" href="#gyroscope" id="ref-for-gyroscope-18">gyroscope</a>, and the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#linear-acceleration">linear acceleration</a> is isolated by removing the isolated gravity, from the <a data-link-type="dfn" href="#accelerometer" id="ref-for-accelerometer-23">accelerometer</a> values.</p>
    <p>This also means that the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="linear-acceleration-sensor">Linear Acceleration Sensor</dfn> and the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="gravity-sensor">Gravity Sensor</dfn> as exposed by most sensor hubs are most likely fusion sensors.</p>
-   <p>Gravity can also be removed from a <a data-link-type="dfn" href="#linear-acceleration-sensor" id="ref-for-linear-acceleration-sensor-3">linear acceleration sensor</a> using a <a data-link-type="dfn" href="#magnetometer-magnetometers" id="ref-for-magnetometer-magnetometers-9">magnetometer</a>,
+   <p>Gravity can also be removed from a <a data-link-type="dfn" href="#linear-acceleration-sensor" id="ref-for-linear-acceleration-sensor-3">linear acceleration sensor</a> using a <a data-link-type="dfn" href="#magnetometer-magnetometers" id="ref-for-magnetometer-magnetometers-10">magnetometer</a>,
 as the <a data-link-type="dfn" href="https://w3c.github.io/magnetometer#magnetic-field">magnetic field</a> vector is more or less stable.</p>
    <p class="note" role="note"><span>Note,</span> as the gravity changes with the frequency of the movements, i.e., 0 in falling direction
 in free fall, you can imagine that <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#linear-acceleration">linear acceleration</a> will be quite imprecise if you are
@@ -1887,6 +1886,7 @@ trying to detect a shake, so keep that in mind.</p>
    <li><a href="#magnetometer-magnetometers">Magnetometers</a><span>, in §3.3</span>
    <li><a href="#orientation-sensor">Orientation Sensor</a><span>, in §4.3</span>
    <li><a href="#relative-orientation-sensor">Relative Orientation Sensor</a><span>, in §4.5</span>
+   <li><a href="#tilt-compensation">tilt compensation</a><span>, in §3.3</span>
   </ul>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
   <ul class="index">
@@ -1939,10 +1939,10 @@ trying to detect a shake, so keep that in mind.</p>
     <li><a href="#ref-for-accelerometer-2">3.1. Accelerometer</a>
     <li><a href="#ref-for-accelerometer-3">4.1. Common fusion sensors</a> <a href="#ref-for-accelerometer-4">(2)</a> <a href="#ref-for-accelerometer-5">(3)</a> <a href="#ref-for-accelerometer-6">(4)</a> <a href="#ref-for-accelerometer-7">(5)</a>
     <li><a href="#ref-for-accelerometer-8">4.3. Orientation Sensor</a> <a href="#ref-for-accelerometer-9">(2)</a> <a href="#ref-for-accelerometer-10">(3)</a>
-    <li><a href="#ref-for-accelerometer-11">4.4. Geomagnetic Orientation Sensor</a>
-    <li><a href="#ref-for-accelerometer-12">4.5. Relative Orientation Sensor</a> <a href="#ref-for-accelerometer-13">(2)</a>
-    <li><a href="#ref-for-accelerometer-14">4.5.1. Complementary filter</a> <a href="#ref-for-accelerometer-15">(2)</a> <a href="#ref-for-accelerometer-16">(3)</a> <a href="#ref-for-accelerometer-17">(4)</a> <a href="#ref-for-accelerometer-18">(5)</a> <a href="#ref-for-accelerometer-19">(6)</a> <a href="#ref-for-accelerometer-20">(7)</a>
-    <li><a href="#ref-for-accelerometer-21">4.6. Gravity and Linear Acceleration Sensor</a> <a href="#ref-for-accelerometer-22">(2)</a>
+    <li><a href="#ref-for-accelerometer-11">4.4. Geomagnetic Orientation Sensor</a> <a href="#ref-for-accelerometer-12">(2)</a>
+    <li><a href="#ref-for-accelerometer-13">4.5. Relative Orientation Sensor</a> <a href="#ref-for-accelerometer-14">(2)</a>
+    <li><a href="#ref-for-accelerometer-15">4.5.1. Complementary filter</a> <a href="#ref-for-accelerometer-16">(2)</a> <a href="#ref-for-accelerometer-17">(3)</a> <a href="#ref-for-accelerometer-18">(4)</a> <a href="#ref-for-accelerometer-19">(5)</a> <a href="#ref-for-accelerometer-20">(6)</a> <a href="#ref-for-accelerometer-21">(7)</a>
+    <li><a href="#ref-for-accelerometer-22">4.6. Gravity and Linear Acceleration Sensor</a> <a href="#ref-for-accelerometer-23">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="inertial-frame-sensor">
@@ -1960,8 +1960,8 @@ trying to detect a shake, so keep that in mind.</p>
     <li><a href="#ref-for-gyroscope-8">4.3. Orientation Sensor</a>
     <li><a href="#ref-for-gyroscope-9">4.4. Geomagnetic Orientation Sensor</a>
     <li><a href="#ref-for-gyroscope-10">4.5. Relative Orientation Sensor</a>
-    <li><a href="#ref-for-gyroscope-11">4.5.1. Complementary filter</a> <a href="#ref-for-gyroscope-12">(2)</a> <a href="#ref-for-gyroscope-13">(3)</a> <a href="#ref-for-gyroscope-14">(4)</a> <a href="#ref-for-gyroscope-15">(5)</a> <a href="#ref-for-gyroscope-16">(6)</a>
-    <li><a href="#ref-for-gyroscope-17">4.6. Gravity and Linear Acceleration Sensor</a>
+    <li><a href="#ref-for-gyroscope-11">4.5.1. Complementary filter</a> <a href="#ref-for-gyroscope-12">(2)</a> <a href="#ref-for-gyroscope-13">(3)</a> <a href="#ref-for-gyroscope-14">(4)</a> <a href="#ref-for-gyroscope-15">(5)</a> <a href="#ref-for-gyroscope-16">(6)</a> <a href="#ref-for-gyroscope-17">(7)</a>
+    <li><a href="#ref-for-gyroscope-18">4.6. Gravity and Linear Acceleration Sensor</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="magnetometer-magnetometers">
@@ -1969,22 +1969,24 @@ trying to detect a shake, so keep that in mind.</p>
    <ul>
     <li><a href="#ref-for-magnetometer-magnetometers-1">1. Introduction</a>
     <li><a href="#ref-for-magnetometer-magnetometers-2">4.1. Common fusion sensors</a> <a href="#ref-for-magnetometer-magnetometers-3">(2)</a> <a href="#ref-for-magnetometer-magnetometers-4">(3)</a> <a href="#ref-for-magnetometer-magnetometers-5">(4)</a>
-    <li><a href="#ref-for-magnetometer-magnetometers-6">4.3. Orientation Sensor</a> <a href="#ref-for-magnetometer-magnetometers-7">(2)</a>
-    <li><a href="#ref-for-magnetometer-magnetometers-8">4.4. Geomagnetic Orientation Sensor</a>
-    <li><a href="#ref-for-magnetometer-magnetometers-9">4.6. Gravity and Linear Acceleration Sensor</a>
+    <li><a href="#ref-for-magnetometer-magnetometers-6">4.3. Orientation Sensor</a> <a href="#ref-for-magnetometer-magnetometers-7">(2)</a> <a href="#ref-for-magnetometer-magnetometers-8">(3)</a>
+    <li><a href="#ref-for-magnetometer-magnetometers-9">4.4. Geomagnetic Orientation Sensor</a>
+    <li><a href="#ref-for-magnetometer-magnetometers-10">4.6. Gravity and Linear Acceleration Sensor</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="low-pass-filter">
    <b><a href="#low-pass-filter">#low-pass-filter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-low-pass-filter-1">3.1. Accelerometer</a> <a href="#ref-for-low-pass-filter-2">(2)</a> <a href="#ref-for-low-pass-filter-3">(3)</a>
+    <li><a href="#ref-for-low-pass-filter-4">4.2.2. High-pass filter</a>
+    <li><a href="#ref-for-low-pass-filter-5">4.5.1. Complementary filter</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="high-pass-filter">
    <b><a href="#high-pass-filter">#high-pass-filter</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-high-pass-filter-1">3.1. Accelerometer</a>
-    <li><a href="#ref-for-high-pass-filter-2">4.5.1. Complementary filter</a>
+    <li><a href="#ref-for-high-pass-filter-1">3.1. Accelerometer</a> <a href="#ref-for-high-pass-filter-2">(2)</a>
+    <li><a href="#ref-for-high-pass-filter-3">4.5.1. Complementary filter</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="orientation-sensor">

--- a/index.html
+++ b/index.html
@@ -1792,8 +1792,8 @@ complementing the <a data-link-type="dfn" href="#gyroscope" id="ref-for-gyroscop
    <p>With α being the weight constant, a the acceleration from <a data-link-type="dfn" href="#accelerometer" id="ref-for-accelerometer-16">accelerometer</a>, ω the angular
 velocity from <a data-link-type="dfn" href="#gyroscope" id="ref-for-gyroscope-12">gyroscope</a> and ∂t being the time between measurements.</p>
    <p>A common value for α is 0.98, which means that 98% of the weight lays on the <a data-link-type="dfn" href="#gyroscope" id="ref-for-gyroscope-13">gyroscope</a> measurements.</p>
-   <div class="example" id="example-7af818b7">
-    <a class="self-link" href="#example-7af818b7"></a> Manually calculate the relative orientation in Euler angles (radian) using a <a data-link-type="dfn" href="#complementary-filter" id="ref-for-complementary-filter-3">complementary filter</a>. 
+   <div class="example" id="example-e1667a72">
+    <a class="self-link" href="#example-e1667a72"></a> Manually calculate the relative orientation in Euler angles (radian) using a <a data-link-type="dfn" href="#complementary-filter" id="ref-for-complementary-filter-3">complementary filter</a>. 
     <p>The <a data-link-type="dfn" href="#gyroscope" id="ref-for-gyroscope-14">gyroscope</a> measures <i><a data-link-type="dfn" href="https://w3c.github.io/gyroscope#angular-velocity">angular velocity</a></i>, so by multiplying with the time difference,
   we get the <i>change of angle</i>. This change is always calculated relative to the current device
   position, so we need to use the <a data-link-type="dfn" href="#accelerometer" id="ref-for-accelerometer-17">accelerometer</a>, which includes gravity, to calibrate this


### PR DESCRIPTION
I did a full editorial pass on this document. Given it was in a great shape already, this PR contains just some grammar checks, nitpicks, and cross-referencing improvements.

(I did not adjust the line length in the source as to not introduce noise.)

PTAL @kenchris et al.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/motion-sensors/editorial.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/motion-sensors/2b9929b...9ed78b7.html)