### PR TITLE
Fix validation errors that block publication

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -350,30 +350,22 @@ table, th, td {
       <td>[=Accelerometer=], [=Gyroscope=], MUST NOT USE [=Magnetometer=]</td>
     </tr>
   </tfoot>
-  <tbody>
     <tr>
       <td>[=Absolute Orientation Sensor=]</td>
       <td>[=Accelerometer=], [=Magnetometer=], AND (when present) [=Gyroscope=]</td>
     </tr>
-  </tbody>
-  <tbody>
     <tr>
       <td>[=Geomagnetic Orientation Sensor=]</td>
       <td>[=Accelerometer=], [=Magnetometer=], MUST NOT USE [=Gyroscope=]</td>
     </tr>
-  </tbody>
-  <tbody>
     <tr>
       <td>[=Gravity Sensor=]</td>
       <td>[=Accelerometer=], [=Gyroscope=]</td>
     </tr>
-  </tbody>
-  <tbody>
     <tr>
       <td>[=Linear Acceleration Sensor=]</td>
       <td>[=Accelerometer=], AND EITHER [=Gyroscope=] OR [=Magnetometer=]</td>
     </tr>
-  </tbody>
 </table>
 
 ## Low and high pass filters ## {#pass-filters}

--- a/index.html
+++ b/index.html
@@ -1654,15 +1654,12 @@ hardware, it most often makes sense to use these from a power and performance po
      <tr>
       <td><a data-link-type="dfn" href="#absolute-orientation-sensor" id="ref-for-absolute-orientation-sensor">Absolute Orientation Sensor</a>
       <td><a data-link-type="dfn" href="#accelerometer" id="ref-for-accelerometer③">Accelerometer</a>, <a data-link-type="dfn" href="#magnetometer-magnetometers" id="ref-for-magnetometer-magnetometers②">Magnetometer</a>, AND (when present) <a data-link-type="dfn" href="#gyroscope" id="ref-for-gyroscope②">Gyroscope</a>
-    <tbody>
      <tr>
       <td><a data-link-type="dfn" href="#geomagnetic-orientation-sensor" id="ref-for-geomagnetic-orientation-sensor">Geomagnetic Orientation Sensor</a>
       <td><a data-link-type="dfn" href="#accelerometer" id="ref-for-accelerometer④">Accelerometer</a>, <a data-link-type="dfn" href="#magnetometer-magnetometers" id="ref-for-magnetometer-magnetometers③">Magnetometer</a>, MUST NOT USE <a data-link-type="dfn" href="#gyroscope" id="ref-for-gyroscope③">Gyroscope</a>
-    <tbody>
      <tr>
       <td><a data-link-type="dfn" href="#gravity-sensor" id="ref-for-gravity-sensor①">Gravity Sensor</a>
       <td><a data-link-type="dfn" href="#accelerometer" id="ref-for-accelerometer⑤">Accelerometer</a>, <a data-link-type="dfn" href="#gyroscope" id="ref-for-gyroscope④">Gyroscope</a>
-    <tbody>
      <tr>
       <td><a data-link-type="dfn" href="#linear-acceleration-sensor" id="ref-for-linear-acceleration-sensor①">Linear Acceleration Sensor</a>
       <td><a data-link-type="dfn" href="#accelerometer" id="ref-for-accelerometer⑥">Accelerometer</a>, AND EITHER <a data-link-type="dfn" href="#gyroscope" id="ref-for-gyroscope⑤">Gyroscope</a> OR <a data-link-type="dfn" href="#magnetometer-magnetometers" id="ref-for-magnetometer-magnetometers④">Magnetometer</a>


### PR DESCRIPTION
Element “tbody” not allowed as child of element “table” in this context.
https://lists.w3.org/Archives/Public/public-tr-notifications/2017Aug/0068.html

This fix is needed in order to pass HTML validation, a prerequisite for publishing an updated Working Draft. Does not impact the rendering of the table AFAICT.

@kenchris PTAL.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/motion-sensors/validation-fix-for-wd.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/motion-sensors/c853120...c5cd129.html)